### PR TITLE
Clean up actionConfirmPledges(). reformat Confirmation Email

### DIFF
--- a/protected/controllers/PledgeController.php
+++ b/protected/controllers/PledgeController.php
@@ -205,63 +205,175 @@ class PledgeController extends Controller
 	{
 		$giftIds = Yii::app()->input->post("giftId", array()); //array of gift ids we're pledging
 		$deliverDate = Yii::app()->input->post("deliveryDate", array()); //indexed by shelterid
-		
-		$email = "Thank you so very much for your kind and generous gift(s). You never know how an act of kindness, like the one you have shown, will affect others. Maybe that one gift/card can give them the encouragement they need to not only make a difference in their day, but in their life.";
-
 		$shelterIds = array_keys($deliverDate);
+		$data = array(
+			'pledgeCount' => 0,
+			'shelterCount' => 0,
+			'shelters' => array()		// keyed by shelter_id
+		);
+
+		/*
+			collect all the pledges and create a $data array to pass to the confirmation Email. Format is: 
+			array(
+				'pledgeCount' => <int>,
+				'shelterCount' => <int>,
+				'shelters' => array(
+					<shelter_id> => array(
+						'shelter' => <shelfter_object>,
+						'dropoffs' => <array_of_dropoff_objects>,
+						'stories' => array(
+							<story_id> => array(
+								'story' => <story_object>,
+								'gifts' => array(
+									<gift_object>,
+									...
+								)
+							),
+							...
+						)
+					)
+					...
+				)
+			)
+
+		*/
+		foreach($giftIds as $giftId)
+		{
+			$gift = Gifts::model()->findByPk($giftId);
+
+			if ($gift) {
+				$story = Stories::model()->findByPk($gift->story_id);
+
+				if ($story) {
+					$shelter = Shelters::model()->findByPk($story->shelter_id);
+
+					if ($shelter) {
+						$shelterId = $story->shelter_id;
+						$data['pledgeCount']++;
+
+						if (empty($data['shelters'][$shelterId])) {
+							$data['shelterCount']++;
+							$data['shelters'][$shelterId] = array(
+								'shelter' => $shelter,
+								'dropoffs' => ShelterDropoffs::model()->findAllByAttributes(array('shelter_id' => $shelterId)),
+								'stories' => array()
+							);
+						}
+
+						if (empty($data['shelters'][$shelterId]['stories'][$gift->story_id])) {
+							$data['shelters'][$shelterId]['stories'][$gift->story_id] = array(
+								'story' => $story, 
+								'gifts' => array()
+							);
+						}
+
+						$data['shelters'][$shelterId]['stories'][$gift->story_id]['gifts'][] = $gift;
+						
+						//create a pledge
+						$pledge = new Pledges();
+						$pledge->gift_id = $giftId;
+						$pledge->user_id = Yii::app()->user->id;
+						$pledge->status = "pledged";
+						$pledge->estimated_delivery_date = date("Y-m-d", strtotime($deliverDate[$story->shelter_id]));
+						$pledge->date_created = new CDbExpression('NOW()');
+						$pledge->save();
+
+					}
+
+				}
+
+			}
+			
+		}
+		
+		if ($this->sendConfirmEmail($data)) {
+
+			//reset session
+			unset(Yii::app()->session['pledgeCart']);
+
+			$this->redirect($this->createUrl("pledge/thankYou"));
+
+		} else {
+			// WTF Emailed failed (or debug)
+		}
+
+	}
+
+	public function actionThankYou()
+	{
+		$this->render("/pledge/thankYou/main", array(
+		));
+	}
+
+	protected function sendConfirmEmail($data) 
+	{
+		$email = "Thank you so very much for your kind and generous gift(s). You never know how an act of kindness, like the one you have shown, will affect others. Maybe that one gift/card can give them the encouragement they need to not only make a difference in their day, but in their life.";
+		$email .= "\n\nHere is a copy of your pledge order. Please print this email and bring it with you when dropping off gifts.";
+
 
 		$email .= "\n\nSUMMARY (Please print for your own records)";
 		$email .= "\n\n=====================================";
-		$email .= "\n\nSHELTERS:";
+		$email .= "\n\nTOTAL PLEDGES: ".$data['pledgeCount'];
+		$email .=   "\nTOTAL SHELTERS: ".$data['shelterCount'];
+		$email .= "\n";
 
-		foreach($shelterIds as $shelterId)
-		{
-			$shelter = Shelters::model()->findByPk($shelterId);
+		$shelterIndex = 1;
+		foreach ($data['shelters'] as $shelterId => $shelterData) {
+
+			$email .=   "\n=====================================";
+			$email .= "\n\nSHELTER ".$shelterIndex.":";
+
+			$shelter = $shelterData['shelter'];
+			$dropoffLocations = $shelterData['dropoffs'];
 
 			$email .= "\n\nShelter Name: {$shelter->name}";
 			$email .= "\nStreet: {$shelter->street}";
 			$email .= "\nPhone: {$shelter->phone}";
 
-			$dropoffLocations = ShelterDropoffs::model()->findAllByAttributes(array(
-				'shelter_id' => $shelter->shelter_id
-			));
 
-			if(!empty($dropoffLocations))
-			{
-				$email .= "\nDropoff Locations:";
+			if(!empty($dropoffLocations)) {
+				$email .= "\n\nDROP OFF LOCATIONS:";
+				$email .=   "\n-------------------";
 
-				foreach($dropoffLocations as $location)
-				{
+				foreach($dropoffLocations as $location) {
 					$email .= "\nName: {$location->name}";
-					$email .= "\Address: {$location->address}";
+					$email .= "\nAddress: {$location->address}";
 					$email .= "\nNotes: {$location->notes}";
+					$email .= "\n";
 				}
 			}
+
+			$email .= "\n\nPLEDGES:";
+			$email .=   "\n-------------------";
+
+			foreach($shelterData['stories'] as $storyData)
+			{
+				$story = $storyData['story'];
+				$gifts = $storyData['gifts'];
+
+				$email .= "\nName: ".$story->fname.$story->lname;
+				$email .= "\nID: ".$story->assigned_id;
+
+				foreach ($gifts as $gift) {
+					$email .= "\nGift: ".$gift->description;
+				}
+
+				$email .= "\n";
+			}
+
+			$shelterIndex++;
 		}
 
-		$email .= "\n\n=====================================";
+		$email .=   "\n=====================================";
 
-		$email .= "\n\n PLEDGES:";
 
-		foreach($giftIds as $giftId)
-		{
-			$gift = Gifts::model()->findByPk($giftId);
-			$story = Stories::model()->findByPk($gift->story_id);
-			$shelter = Shelters::model()->findByPk($shelterId);
+		$email .= "\n\nIf you are unable to pledge one or more gifts, please email <pledges@homelesspartners.com> or reply to this email.";
+		$email .= "\n\nThank you for your pledge,";
+		$email .= "\n\n- Homeless Partners";
 
-			//create a pledge
-			$pledge = new Pledges();
-			$pledge->gift_id = $giftId;
-			$pledge->user_id = Yii::app()->user->id;
-			$pledge->status = "pledged";
-			$pledge->estimated_delivery_date = date("Y-m-d", strtotime($deliverDate[$story->shelter_id]));
-			$pledge->date_created = new CDbExpression('NOW()');
-			$pledge->save();
-			
-			$email .= "\n\n Gift: {$gift->description}";
-			$email .= "\n For shelter: {$shelter->name} (See above for dropoff locations)";
-			$email .= "\n Estimated drop off date: " . date("F j, Y", strtotime($deliverDate[$story->shelter_id]));
-		}
+
+		//echo nl2br(htmlentities($email));
+		//return false;	// debug
 
 		$emailer = new Email();
 		$result = $emailer->send(
@@ -271,15 +383,7 @@ class PledgeController extends Controller
 			$email
 		);
 
-		//reset session
-		unset(Yii::app()->session['pledgeCart']);
-
-		$this->redirect($this->createUrl("pledge/thankYou"));
-	}
-
-	public function actionThankYou()
-	{
-		$this->render("/pledge/thankYou/main", array(
-		));
+		// successful email
+		return true;
 	}
 }


### PR DESCRIPTION
Moved all the Email formatting logic into a new function called sendConfirmationEmail(). Pass an array of all the $data needed to format the email. The actual actionConfirmPledges() action now just groups the data into a hierarchy of: Shelters->Stories->Gifts,  creates the Pledge and redirects. 
